### PR TITLE
修复当其他用户浏览器默认名称不为Google Chrome时启动失败问题

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -37,7 +37,7 @@ module.exports = {
       template: 'src/index.html', // Load a custom template
       inject: 'body' // Inject all scripts into the body 
     }),
-    new OpenBrowserPlugin({url: 'http://localhost:3000/',browser:'Google Chrome'}),
+    new OpenBrowserPlugin({url: 'http://localhost:3000/'}),
     new CopyWebpackPlugin([{
       from: path.join(__dirname,'/public')   // 打包public静态资源
     }])


### PR DESCRIPTION
有的人客户端chrome浏览器可能不叫"Google Chrome",启动会失败。
后面默认不填就好。